### PR TITLE
PR.1640 - Fixing bugs with BasicGet and BasicNack

### DIFF
--- a/RabbitMQ.Fakes.Tests/FakeModelTests.cs
+++ b/RabbitMQ.Fakes.Tests/FakeModelTests.cs
@@ -627,7 +627,7 @@ namespace RabbitMQ.Fakes.Tests
             model.BasicConsume("my_queue", false, new EventingBasicConsumer(model));
 
             // Act
-            var deliveryTag = model._workingMessages.First().Key;
+            var deliveryTag = model.WorkingMessages.First().Key;
             model.BasicAck(deliveryTag, false);
 
             // Assert
@@ -705,7 +705,7 @@ namespace RabbitMQ.Fakes.Tests
             model.BasicConsume("my_queue", false, new EventingBasicConsumer(model));
 
             // act
-            var deliveryTag = model._workingMessages.First().Key;
+            var deliveryTag = model.WorkingMessages.First().Key;
             model.BasicNack(deliveryTag, false, requeue);
 
             // assert

--- a/RabbitMQ.Fakes.Tests/FakeModelTests.cs
+++ b/RabbitMQ.Fakes.Tests/FakeModelTests.cs
@@ -712,10 +712,12 @@ namespace RabbitMQ.Fakes.Tests
             if (requeue)
             {
                 Assert.That(node.Queues["my_queue"].Messages.Count, Is.EqualTo(1));
+                Assert.That(model.WorkingMessages.Count, Is.EqualTo(1));
             }
             else
             {
                 Assert.That(node.Queues["my_queue"].Messages.Count, Is.EqualTo(0));
+                Assert.That(model.WorkingMessages.IsEmpty);
             }
         }
 
@@ -741,10 +743,12 @@ namespace RabbitMQ.Fakes.Tests
             if (shouldBeRemovedFromQueue)
             {
                 Assert.That(node.Queues["my_queue"].Messages.Count, Is.EqualTo(0));
+                Assert.That(model.WorkingMessages.IsEmpty);
             }
             else
             {
                 Assert.That(node.Queues["my_queue"].Messages.Count, Is.EqualTo(1));
+                Assert.That(model.WorkingMessages.Count, Is.EqualTo(1));
             }
         }
     }

--- a/RabbitMQ.Fakes/FakeModel.cs
+++ b/RabbitMQ.Fakes/FakeModel.cs
@@ -372,7 +372,7 @@ namespace RabbitMQ.Fakes
         private long _lastDeliveryTag;
         public readonly ConcurrentDictionary<ulong, RabbitMessage> _workingMessages = new ConcurrentDictionary<ulong, RabbitMessage>();
 
-        public BasicGetResult BasicGet(string queue, bool noAck)
+        public BasicGetResult BasicGet(string queue, bool autoAck)
         {
             Queue queueInstance;
             _server.Queues.TryGetValue(queue, out queueInstance);
@@ -381,7 +381,14 @@ namespace RabbitMQ.Fakes
                 return null;
 
             RabbitMessage message;
-            queueInstance.Messages.TryDequeue(out message);
+            if (autoAck)
+            {
+                queueInstance.Messages.TryDequeue(out message);
+            }
+            else
+            {
+                queueInstance.Messages.TryPeek(out message);
+            }
 
             if (message == null)
                 return null;

--- a/RabbitMQ.Fakes/FakeModel.cs
+++ b/RabbitMQ.Fakes/FakeModel.cs
@@ -398,8 +398,15 @@ namespace RabbitMQ.Fakes
             var basicProperties = message.BasicProperties ?? CreateBasicProperties();
             var body = message.Body;
 
-            RabbitMessage UpdateFunction(ulong key, RabbitMessage existingMessage) => existingMessage;
-            WorkingMessages.AddOrUpdate(deliveryTag, message, UpdateFunction);
+            if (autoAck)
+            {
+                WorkingMessages.TryRemove(deliveryTag, out _);
+            }
+            else
+            {
+                RabbitMessage UpdateFunction(ulong key, RabbitMessage existingMessage) => existingMessage;
+                WorkingMessages.AddOrUpdate(deliveryTag, message, UpdateFunction);
+            }
 
             return new BasicGetResult(deliveryTag, redelivered, exchange, routingKey, messageCount, basicProperties, body);
         }


### PR DESCRIPTION
BasicGet:
- Updated to only remove the message from Rabbit if autoAck param is true

BasicNack
- Updated so that Nacking a message will leave the message where it was instead of re-enqueueing a whole new message. 